### PR TITLE
Expand the range from 1970-2040 to 1900-2100

### DIFF
--- a/R/recur-on-wday.R
+++ b/R/recur-on-wday.R
@@ -15,7 +15,7 @@
 #'
 #' It is particularly important to pay attention to the `since` date when using
 #' weekly rules. The day of the week to use comes from the `since` date, which,
-#' by default, is a Thursday (`1970-01-01`).
+#' by default, is a Monday (`1900-01-01`).
 #'
 #' @param x `[rrule]`
 #'
@@ -37,22 +37,22 @@
 #' An updated rrule.
 #'
 #' @examples
-#' # Using default `since` (1970-01-01, a Thursday)
-#' on_weekly_thursdays <- weekly()
+#' # Using default `since` (1900-01-01, a Monday)
+#' on_weekly_mondays <- weekly()
 #'
 #' start <- "1999-01-01" # <- a Friday
 #' end <- "1999-03-01"
 #'
 #' # This finds the first Thursday, and then continues from there
-#' alma_search(start, end, on_weekly_thursdays)
+#' alma_search(start, end, on_weekly_mondays)
 #'
-#' # We start counting from a Friday here, so our `start` date counts
+#' # We start counting from a Friday here
 #' on_weekly_fridays <- weekly(since = start)
 #' alma_search(start, end, on_weekly_fridays)
 #'
 #' # Alternatively, we could use `recur_on_wday()` and force a recurrence rule
 #' # on Friday
-#' on_wday_friday <- on_weekly_thursdays %>% recur_on_wday("Friday")
+#' on_wday_friday <- on_weekly_mondays %>% recur_on_wday("Friday")
 #' alma_search(start, end, on_wday_friday)
 #'
 #' # At monthly frequencies, you can use n-th values to look for particular

--- a/R/rrule.R
+++ b/R/rrule.R
@@ -14,16 +14,15 @@
 #' - `yearly()` Recur on a yearly frequency.
 #'
 #' @details
-#' By default `since` is set to the Unix epoch time, but there is no hard and
-#' fast rule for doing this. Remember that this is the first possible event
-#' date, so you may need to move this date backwards in time if you need to
-#' generate dates before `1970-01-01`.
+#' By default, `since == "1900-01-01"` and `until == "2100-01-01"`, which should
+#' capture most use cases well while still being performant. You may need to
+#' adjust these dates if you want events outside this range.
 #'
-#' In terms of speed, it is more efficient if you adjust the `since` date to
-#' be closer to the first date in the sequence of dates that you are working
-#' with. For example, if you are working with dates in the range of 2019 and
-#' forward, adjust the `since` date to be `2019-01-01` for a significant speed
-#' boost.
+#' In terms of speed, it is generally more efficient if you adjust the `since`
+#' and `until` date to be closer to the first date in the sequence of dates
+#' that you are working with. For example, if you are working with dates in the
+#' range of 2019 and forward, adjust the `since` date to be `2019-01-01` for a
+#' significant speed boost.
 #'
 #' As the anchor date, events are often calculated _relative to_ this
 #' date. As an example, a rule of "on Monday, every other week" would use
@@ -33,7 +32,7 @@
 #' with `monthly() %>% recur_on_interval(3)`. The month to start the quarterly
 #' interval from will be pulled from the `since` date inside `monthly()`. The
 #' default will use a quarterly rule starting in January since the default
-#' `since` date is `1970-01-01`. See the examples.
+#' `since` date is `1900-01-01`. See the examples.
 #'
 #' @param since `[Date(1)]`
 #'
@@ -53,12 +52,12 @@
 #'
 #' alma_search("1970-01-01", "1971-01-01", rrule)
 #'
-#' # Notice that dates before 1970-01-01 are never generated with the defaults!
-#' alma_search("1969-01-01", "1970-01-01", rrule)
+#' # Notice that dates before 1900-01-01 are never generated with the defaults!
+#' alma_search("1899-01-01", "1901-01-01", rrule)
 #'
 #' # Adjust the `since` date to get access to these dates
-#' rrule_pre_1970 <- monthly(since = "1969-01-01") %>% recur_on_mday(25)
-#' alma_search("1969-01-01", "1970-01-01", rrule_pre_1970)
+#' rrule_pre_1900 <- monthly(since = "1850-01-01") %>% recur_on_mday(25)
+#' alma_search("1899-01-01", "1901-01-01", rrule_pre_1900)
 #'
 #' # A quarterly recurrence rule can be built from
 #' # `monthly()` and `recur_on_interval()`
@@ -84,25 +83,25 @@ NULL
 
 #' @rdname rrule
 #' @export
-daily <- function(since = "1970-01-01", until = "2040-01-01") {
+daily <- function(since = "1900-01-01", until = "2100-01-01") {
   rrule(since, until, frequency = "daily")
 }
 
 #' @rdname rrule
 #' @export
-weekly <- function(since = "1970-01-01", until = "2040-01-01") {
+weekly <- function(since = "1900-01-01", until = "2100-01-01") {
   rrule(since, until, frequency = "weekly")
 }
 
 #' @rdname rrule
 #' @export
-monthly <- function(since = "1970-01-01", until = "2040-01-01") {
+monthly <- function(since = "1900-01-01", until = "2100-01-01") {
   rrule(since, until, frequency = "monthly")
 }
 
 #' @rdname rrule
 #' @export
-yearly <- function(since = "1970-01-01", until = "2040-01-01") {
+yearly <- function(since = "1900-01-01", until = "2100-01-01") {
   rrule(since, until, frequency = "yearly")
 }
 
@@ -130,8 +129,8 @@ rrule <- function(since, until, frequency) {
   )
 }
 
-new_rrule <- function(since = as.Date("1970-01-01"),
-                      until = as.Date("2040-01-01"),
+new_rrule <- function(since = as.Date("1900-01-01"),
+                      until = as.Date("2100-01-01"),
                       frequency = "yearly",
                       count = NULL,
                       interval = NULL,

--- a/R/stepper.R
+++ b/R/stepper.R
@@ -121,7 +121,7 @@ stepper <- function(rschedule) {
 
 #' @rdname stepper
 #' @export
-workdays <- function(n, since = "1970-01-01", until = "2040-01-01") {
+workdays <- function(n, since = "1900-01-01", until = "2100-01-01") {
   rschedule <- weekly(since = since, until = until)
   rschedule <- recur_on_weekends(rschedule)
   workdays_stepper <- stepper(rschedule)

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,6 +8,9 @@ delayedAssign("almanac_global_neg_inf_date", structure(-Inf, class = "Date"))
 delayedAssign("almanac_global_na_date", structure(NA_real_, class = "Date"))
 delayedAssign("almanac_global_nan_date", structure(NaN, class = "Date"))
 
+delayedAssign("almanac_global_default_since", as.Date("1900-01-01"))
+delayedAssign("almanac_global_default_until", as.Date("2100-01-01"))
+
 # JS rrule can't seem to handle dates outside this range, but that's fine
 delayedAssign("almanac_global_max_date", as.Date("9999-12-31"))
 delayedAssign("almanac_global_min_date", as.Date("0100-01-01"))

--- a/README.Rmd
+++ b/README.Rmd
@@ -147,3 +147,4 @@ The date shifting / adjusting functions are modeled after similar functions in [
 The fast binary search based implementations of `alma_next()` and `alma_step()` are inspired by Pandas and the implementation of Numpy's [busday_offset()](https://docs.scipy.org/doc/numpy/reference/generated/numpy.busday_offset.html).
 
 The author of [gs](https://github.com/jameslairdsmith/gs), James Laird-Smith, has been a great collaborator as we have bounced ideas off of each other. gs attempts to solve a similar problem, but with a slightly different implementation.
+

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ on_thanksgiving <- yearly() %>%
   recur_on_wday("Thursday", nth = 4)
 
 on_thanksgiving
-#> <rrule[yearly / 1970-01-01 / 2040-01-01]>
+#> <rrule[yearly / 1900-01-01 / 2100-01-01]>
 #> - ymonth: Nov
 #> - wday: Thu[4]
 ```

--- a/man/recur_on_wday.Rd
+++ b/man/recur_on_wday.Rd
@@ -46,25 +46,25 @@ days of the week, call \code{recur_on_wday()} twice with different \code{wday} v
 
 It is particularly important to pay attention to the \code{since} date when using
 weekly rules. The day of the week to use comes from the \code{since} date, which,
-by default, is a Thursday (\code{1970-01-01}).
+by default, is a Monday (\code{1900-01-01}).
 }
 \examples{
-# Using default `since` (1970-01-01, a Thursday)
-on_weekly_thursdays <- weekly()
+# Using default `since` (1900-01-01, a Monday)
+on_weekly_mondays <- weekly()
 
 start <- "1999-01-01" # <- a Friday
 end <- "1999-03-01"
 
 # This finds the first Thursday, and then continues from there
-alma_search(start, end, on_weekly_thursdays)
+alma_search(start, end, on_weekly_mondays)
 
-# We start counting from a Friday here, so our `start` date counts
+# We start counting from a Friday here
 on_weekly_fridays <- weekly(since = start)
 alma_search(start, end, on_weekly_fridays)
 
 # Alternatively, we could use `recur_on_wday()` and force a recurrence rule
 # on Friday
-on_wday_friday <- on_weekly_thursdays \%>\% recur_on_wday("Friday")
+on_wday_friday <- on_weekly_mondays \%>\% recur_on_wday("Friday")
 alma_search(start, end, on_wday_friday)
 
 # At monthly frequencies, you can use n-th values to look for particular

--- a/man/rrule.Rd
+++ b/man/rrule.Rd
@@ -8,13 +8,13 @@
 \alias{yearly}
 \title{Create a recurrence rule}
 \usage{
-daily(since = "1970-01-01", until = "2040-01-01")
+daily(since = "1900-01-01", until = "2100-01-01")
 
-weekly(since = "1970-01-01", until = "2040-01-01")
+weekly(since = "1900-01-01", until = "2100-01-01")
 
-monthly(since = "1970-01-01", until = "2040-01-01")
+monthly(since = "1900-01-01", until = "2100-01-01")
 
-yearly(since = "1970-01-01", until = "2040-01-01")
+yearly(since = "1900-01-01", until = "2100-01-01")
 }
 \arguments{
 \item{since}{\verb{[Date(1)]}
@@ -42,16 +42,15 @@ to them, use one of the \verb{recur_*()} functions.
 }
 }
 \details{
-By default \code{since} is set to the Unix epoch time, but there is no hard and
-fast rule for doing this. Remember that this is the first possible event
-date, so you may need to move this date backwards in time if you need to
-generate dates before \code{1970-01-01}.
+By default, \code{since == "1900-01-01"} and \code{until == "2100-01-01"}, which should
+capture most use cases well while still being performant. You may need to
+adjust these dates if you want events outside this range.
 
-In terms of speed, it is more efficient if you adjust the \code{since} date to
-be closer to the first date in the sequence of dates that you are working
-with. For example, if you are working with dates in the range of 2019 and
-forward, adjust the \code{since} date to be \code{2019-01-01} for a significant speed
-boost.
+In terms of speed, it is generally more efficient if you adjust the \code{since}
+and \code{until} date to be closer to the first date in the sequence of dates
+that you are working with. For example, if you are working with dates in the
+range of 2019 and forward, adjust the \code{since} date to be \code{2019-01-01} for a
+significant speed boost.
 
 As the anchor date, events are often calculated \emph{relative to} this
 date. As an example, a rule of "on Monday, every other week" would use
@@ -61,19 +60,19 @@ There is no \code{quarterly()} recurrence frequency, but this can be accomplishe
 with \code{monthly() \%>\% recur_on_interval(3)}. The month to start the quarterly
 interval from will be pulled from the \code{since} date inside \code{monthly()}. The
 default will use a quarterly rule starting in January since the default
-\code{since} date is \code{1970-01-01}. See the examples.
+\code{since} date is \code{1900-01-01}. See the examples.
 }
 \examples{
 rrule <- monthly() \%>\% recur_on_mday(25)
 
 alma_search("1970-01-01", "1971-01-01", rrule)
 
-# Notice that dates before 1970-01-01 are never generated with the defaults!
-alma_search("1969-01-01", "1970-01-01", rrule)
+# Notice that dates before 1900-01-01 are never generated with the defaults!
+alma_search("1899-01-01", "1901-01-01", rrule)
 
 # Adjust the `since` date to get access to these dates
-rrule_pre_1970 <- monthly(since = "1969-01-01") \%>\% recur_on_mday(25)
-alma_search("1969-01-01", "1970-01-01", rrule_pre_1970)
+rrule_pre_1900 <- monthly(since = "1850-01-01") \%>\% recur_on_mday(25)
+alma_search("1899-01-01", "1901-01-01", rrule_pre_1900)
 
 # A quarterly recurrence rule can be built from
 # `monthly()` and `recur_on_interval()`

--- a/man/stepper.Rd
+++ b/man/stepper.Rd
@@ -13,7 +13,7 @@ x \%s+\% y
 
 x \%s-\% y
 
-workdays(n, since = "1970-01-01", until = "2040-01-01")
+workdays(n, since = "1900-01-01", until = "2100-01-01")
 }
 \arguments{
 \item{rschedule}{\verb{[rschedule]}

--- a/tests/testthat/output/test-radjusted.txt
+++ b/tests/testthat/output/test-radjusted.txt
@@ -6,10 +6,10 @@ basic method
 <radjusted>
 
 Adjust:
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 
 Adjust on:
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 
 
 with rbundles
@@ -21,7 +21,7 @@ with rbundles
 <radjusted>
 
 Adjust:
-<rrule[weekly / 1970-01-01 / 2040-01-01]>
+<rrule[weekly / 1900-01-01 / 2100-01-01]>
 - wday: Wed
 
 Adjust on:

--- a/tests/testthat/output/test-rrule-print.txt
+++ b/tests/testthat/output/test-rrule-print.txt
@@ -3,17 +3,17 @@ basic method
 ============
 
 > daily()
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 
 > yearly()
-<rrule[yearly / 1970-01-01 / 2040-01-01]>
+<rrule[yearly / 1900-01-01 / 2100-01-01]>
 
 
 until is overriden by recur_for_count()
 =======================================
 
 > recur_for_count(daily(), 5)
-<rrule[daily / 1970-01-01 / ???]>
+<rrule[daily / 1900-01-01 / ???]>
 - count: 5
 
 
@@ -21,7 +21,7 @@ can add multiple conditions
 ===========================
 
 > recur_on_interval(recur_for_count(yearly(), 5), 2)
-<rrule[yearly / 1970-01-01 / ???]>
+<rrule[yearly / 1900-01-01 / ???]>
 - count: 5
 - interval: 2
 
@@ -30,7 +30,7 @@ can use multiple ymonths
 ========================
 
 > recur_on_ymonth(daily(), c("Feb", "Mar"))
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - ymonth: Feb, Mar
 
 
@@ -38,7 +38,7 @@ can use multiple yweeks
 =======================
 
 > recur_on_yweek(daily(), c(5, 9, 12))
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - yweek: 5, 9, 12
 
 
@@ -46,7 +46,7 @@ can use multiple ydays
 ======================
 
 > recur_on_yday(daily(), c(5, 9, 12))
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - yday: 5, 9, 12
 
 
@@ -54,7 +54,7 @@ can use multiple mdays
 ======================
 
 > recur_on_mday(daily(), c(5, 9, 12))
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - mday: 5, 9, 12
 
 
@@ -62,15 +62,15 @@ can use wday variations
 =======================
 
 > recur_on_wday(daily(), c("Mon", "Thu"), nth = c(1, 2))
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - wday: Mon[1, 2], Thu[1, 2]
 
 > recur_on_wday(recur_on_wday(daily(), "Mon", nth = c(1, 2)), "Thu", nth = c(4, 5))
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - wday: Mon[1, 2], Thu[4, 5]
 
 > recur_on_wday(yearly(), "Mon", nth = c(1, 2, 10, 13, 15, 16))
-<rrule[yearly / 1970-01-01 / 2040-01-01]>
+<rrule[yearly / 1900-01-01 / 2100-01-01]>
 - wday: Mon[1, 2, 10, 13, 15, ...]
 
 
@@ -78,11 +78,11 @@ can use multiple positions
 ==========================
 
 > recur_on_position(weekly(), c(-1, 2, 3, -2))
-<rrule[weekly / 1970-01-01 / 2040-01-01]>
+<rrule[weekly / 1900-01-01 / 2100-01-01]>
 - position: -2, -1, 2, 3
 
 > recur_on_position(yearly(), c(-1, 2, 3, -2, 10, 12, 13))
-<rrule[yearly / 1970-01-01 / 2040-01-01]>
+<rrule[yearly / 1900-01-01 / 2100-01-01]>
 - position: -2, -1, 2, 3, 10, ...
 
 
@@ -90,7 +90,7 @@ can change offset
 =================
 
 > recur_on_easter(weekly(), offset = -1)
-<rrule[weekly / 1970-01-01 / 2040-01-01]>
+<rrule[weekly / 1900-01-01 / 2100-01-01]>
 - easter: offset = -1
 
 
@@ -98,42 +98,42 @@ each recur_ condition works
 ===========================
 
 > recur_for_count(daily(), 5)
-<rrule[daily / 1970-01-01 / ???]>
+<rrule[daily / 1900-01-01 / ???]>
 - count: 5
 
 > recur_on_interval(daily(), 5)
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - interval: 5
 
 > recur_with_week_start(daily(), "Tuesday")
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - week start: Tue
 
 > recur_on_ymonth(daily(), "Feb")
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - ymonth: Feb
 
 > recur_on_yweek(daily(), 5)
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - yweek: 5
 
 > recur_on_yday(daily(), 5)
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - yday: 5
 
 > recur_on_mday(daily(), 5)
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - mday: 5
 
 > recur_on_wday(daily(), "Wed")
-<rrule[daily / 1970-01-01 / 2040-01-01]>
+<rrule[daily / 1900-01-01 / 2100-01-01]>
 - wday: Wed
 
 > recur_on_position(weekly(), 5)
-<rrule[weekly / 1970-01-01 / 2040-01-01]>
+<rrule[weekly / 1900-01-01 / 2100-01-01]>
 - position: 5
 
 > recur_on_easter(weekly())
-<rrule[weekly / 1970-01-01 / 2040-01-01]>
+<rrule[weekly / 1900-01-01 / 2100-01-01]>
 - easter: offset = 0
 

--- a/tests/testthat/test-alma-next.R
+++ b/tests/testthat/test-alma-next.R
@@ -6,7 +6,7 @@ test_that("can use a rbundle with no rules", {
 test_that("next works with infinite dates", {
   expect_identical(alma_next(almanac_global_inf_date, daily()), almanac_global_na_date)
 
-  expect_identical(alma_next(almanac_global_neg_inf_date, daily()), new_date(0))
+  expect_identical(alma_next(almanac_global_neg_inf_date, daily()), almanac_global_default_since)
   expect_identical(alma_next(almanac_global_neg_inf_date, daily(since = "1970-01-02")), new_date(1))
 
   # If a cache already exists...
@@ -14,7 +14,7 @@ test_that("next works with infinite dates", {
   alma_next("1970-01-01", rrule, inclusive = TRUE)
 
   expect_identical(alma_next(almanac_global_inf_date, rrule), almanac_global_na_date)
-  expect_identical(alma_next(almanac_global_neg_inf_date, rrule), new_date(0))
+  expect_identical(alma_next(almanac_global_neg_inf_date, rrule), almanac_global_default_since)
 })
 
 test_that("alma_next() works with missing dates", {

--- a/tests/testthat/test-misc-cache.R
+++ b/tests/testthat/test-misc-cache.R
@@ -49,9 +49,9 @@ test_that("cache `since` date respects `rdate`s", {
 
   rb <- rbundle()
   rb <- add_rschedule(rb, rrule)
-  rb <- add_rdate(rb, "1950-01-01")
+  rb <- add_rdate(rb, "1899-01-05")
 
-  expect <- as.Date(c("1950-01-01", "1970-01-01"))
+  expect <- as.Date(c("1899-01-05", "1900-01-01"))
 
-  expect_equal(alma_search("1930-01-01", "1970-01-01", rb), expect)
+  expect_equal(alma_search("1899-01-01", "1900-01-01", rb), expect)
 })

--- a/tests/testthat/test-recur-on-interval.R
+++ b/tests/testthat/test-recur-on-interval.R
@@ -2,7 +2,7 @@
 # Basic tests with all frequencies
 
 test_that("daily - on a interval", {
-  base <- daily()
+  base <- daily(since = "1990-01-01")
   rrule <- base %>% recur_on_interval(5)
 
   expect <- as.Date("1990-01-01") + c(0, 5, 10, 15, 20)

--- a/tests/testthat/test-recur-on-ymonth.R
+++ b/tests/testthat/test-recur-on-ymonth.R
@@ -16,7 +16,8 @@ test_that("daily - on a ymonth", {
 })
 
 test_that("weekly - on a ymonth", {
-  base <- weekly()
+  # A Monday
+  base <- weekly(since = "1990-01-01")
   rrule <- base %>% recur_on_ymonth(5)
 
   start <- "1990-01-01"
@@ -24,9 +25,13 @@ test_that("weekly - on a ymonth", {
 
   x <- alma_search(start, stop, rrule)
 
-  expect_equal(x[1], as.Date("1990-05-03"))
-  expect_equal(x[length(x)], as.Date("1991-05-30"))
-  expect_length(x, 10)
+  # First monday in the 5th month
+  expect_equal(x[1], as.Date("1990-05-07"))
+
+  expect_equal(x[length(x)], as.Date("1991-05-27"))
+
+  # 4 mondays in 5th month of 1990, and 4 in the 5th month of 1991
+  expect_length(x, 8)
 })
 
 test_that("monthly - on a ymonth", {

--- a/vignettes/almanac.Rmd
+++ b/vignettes/almanac.Rmd
@@ -51,7 +51,7 @@ alma_search(from = "1990-01-01", to = "1995-12-31", on_yearly)
 
 What if we want a yearly value, but we want it on January 5th every year, rather than on the 1st? `yearly()` has an important argument called `since` that controls two things: the start date of the recurrence rule, and information such as the month, or the day of the month to use if no other conditions have been specified to override those.
 
-The default of `since` is set to `1970-01-01`, the Unix epoch, but this is arbitrary. It is because of this default that in the above example with `alma_search()` we get values on January 1st. Let's change that.
+The default of `since` is set to `1900-01-01`, but this is arbitrary. It is because of this default that in the above example with `alma_search()` we get values on January 1st. Let's change that.
 
 ```{r}
 on_yearly_jan_5 <- yearly(since = "1990-01-05")
@@ -66,7 +66,7 @@ Now that the `since` date has been set to 1990, if we try and find yearly dates 
 alma_search("1988-01-01", "1995-12-31", on_yearly_jan_5)
 ```
 
-There is also an `until` argument to `yearly()` that controls the upper bound of the range to look in. This is arbitrarily set to `2040-01-01`, but can be expanded or contracted as required.
+There is also an `until` argument to `yearly()` that controls the upper bound of the range to look in. This is arbitrarily set to `2100-01-01`, but can be expanded or contracted as required.
 
 ## Event Set
 


### PR DESCRIPTION
This should be fast enough in pretty much all cases, and avoids 95% of possible confusion around the boundary dates